### PR TITLE
label type is set to string/integer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 docs
+*Rproj

--- a/R/spdata_validate.R
+++ b/R/spdata_validate.R
@@ -9,6 +9,9 @@
 #'
 #' @examples
 #' spdata_validate(
+#'   system.file("extdata", "spatialdata-v0.1", package = "SpatialData.validate")
+#' )
+#' spdata_validate(
 #'   system.file("extdata", "spatialdata-v0.3", package = "SpatialData.validate")
 #' )
 spdata_validate <- function(path, s3_client = NULL) {

--- a/R/spdata_validate.R
+++ b/R/spdata_validate.R
@@ -9,7 +9,7 @@
 #'
 #' @examples
 #' spdata_validate(
-#'   system.file("extdata", "spatialdata-v0.5", "zarr-v3", package = "SpatialData.validate")
+#'   system.file("extdata", "spatialdata-v0.3", package = "SpatialData.validate")
 #' )
 spdata_validate <- function(path, s3_client = NULL) {
   group_attributes <- Rarr::read_zarr_attributes(path, s3_client = s3_client)

--- a/inst/extdata/schemas/0.1/image.schema
+++ b/inst/extdata/schemas/0.1/image.schema
@@ -86,7 +86,7 @@
                 ]
               },
               "label": {
-                "type": "string"
+                "type": ["string", "integer"]
               },
               "family": {
                 "type": "string"

--- a/inst/extdata/schemas/0.3/image.schema
+++ b/inst/extdata/schemas/0.3/image.schema
@@ -104,7 +104,7 @@
                 ]
               },
               "label": {
-                "type": "string"
+                "type": ["string", "integer"]
               },
               "family": {
                 "type": "string"

--- a/man/spdata_validate.Rd
+++ b/man/spdata_validate.Rd
@@ -19,6 +19,9 @@ Validate the images/ component of a spatial data file
 }
 \examples{
 spdata_validate(
+  system.file("extdata", "spatialdata-v0.1", package = "SpatialData.validate")
+)
+spdata_validate(
   system.file("extdata", "spatialdata-v0.3", package = "SpatialData.validate")
 )
 }

--- a/man/spdata_validate.Rd
+++ b/man/spdata_validate.Rd
@@ -19,6 +19,6 @@ Validate the images/ component of a spatial data file
 }
 \examples{
 spdata_validate(
-  system.file("extdata", "spatialdata-v0.5", "zarr-v3", package = "SpatialData.validate")
+  system.file("extdata", "spatialdata-v0.3", package = "SpatialData.validate")
 )
 }


### PR DESCRIPTION
This is not too common for SpatialData objects but some RGB images come with channel names 0,1,2. Setting label type to string/integer is an easy fix. 

```
> path <- system.file("extdata", "blobs_v3.zarr", package="SpatialData")
> SpatialData.validate::spdata_validate(file.path(path, "images/blobs_multiscale_image/"))
[1] TRUE
```

Here is a related issue: https://github.com/Huber-group-EMBL/rome/issues/7